### PR TITLE
8305682: Update the javadoc in the Character class to state support for GB 18030-2022 Implementation Level 2

### DIFF
--- a/src/java.base/share/classes/java/lang/Character.java
+++ b/src/java.base/share/classes/java/lang/Character.java
@@ -55,7 +55,7 @@ import jdk.internal.HotSpotIntrinsicCandidate;
  * of the Unicode Standard, with two extensions. First, the Java SE 11 Platform
  * allows an implementation of class {@code Character} to use the code points
  * in the range of {@code U+9FEB} to {@code U+9FEF} from the Unicode Standard
- * version 11.0, in order for the class to allow the "Implementation Level 1"
+ * version 11.0, in order for the class to allow the "Implementation Level 2"
  * of the Chinese GB18030-2022 standard. Second, the Java SE 11 Platform
  * allows an implementation of class {@code Character} to use the Japanese Era
  * code point, {@code U+32FF}, from the Unicode Standard version 12.1.


### PR DESCRIPTION
This is to support GB18030-2022 "Implementation Level 2", an extension to [JDK-8301401](https://bugs.openjdk.org/browse/JDK-8301401). Although all the required code points for Implementation Level 2 are included in JDK 11, the javadoc in the Character class needs to be changed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires CSR request [JDK-8305685](https://bugs.openjdk.org/browse/JDK-8305685) to be approved

### Issues
 * [JDK-8305682](https://bugs.openjdk.org/browse/JDK-8305682): Update the javadoc in the Character class to state support for GB 18030-2022 Implementation Level 2
 * [JDK-8305685](https://bugs.openjdk.org/browse/JDK-8305685): Update the javadoc in the Character class to state support for GB 18030-2022 Implementation Level 2 (**CSR**)


### Reviewers
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk11u-ri.git pull/8/head:pull/8` \
`$ git checkout pull/8`

Update a local copy of the PR: \
`$ git checkout pull/8` \
`$ git pull https://git.openjdk.org/jdk11u-ri.git pull/8/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 8`

View PR using the GUI difftool: \
`$ git pr show -t 8`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk11u-ri/pull/8.diff">https://git.openjdk.org/jdk11u-ri/pull/8.diff</a>

</details>


### Webrev
[Link to Webrev Comment](https://git.openjdk.org/jdk11u-ri/pull/8#issuecomment-1499671454)